### PR TITLE
Fix issue that casues serial createChar to overrun

### DIFF
--- a/QwiicSerLCD.cpp
+++ b/QwiicSerLCD.cpp
@@ -297,7 +297,7 @@ void QwiicSerLCD::createChar(byte location, byte charmap[]) {
     transmit(charmap[i]);
   } // for
   endTransmission();
-  delay(10);
+  delay(50);  //This takes a bit longer
 }
 /*
  * Write a customer character to the display


### PR DESCRIPTION
Increase delay after creating a customer character to prevent over-running serial communications.

Closes #10 