### PR TITLE
Explicitly cast numeric literals to type byte to avoid ESP32 and ESP8266 compile errors

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -39,11 +39,11 @@ setContrast	KEYWORD2
 setAddress	KEYWORD2
 command	KEYWORD2
 specialCommand	KEYWORD2
-enableSystemMessages    KEYWORD2
-disableSystemMessages    KEYWORD2
-enableSplash    KEYWORD2
-disableSplash    KEYWORD2
-saveSplash    KEYWORD2
+enableSystemMessages	KEYWORD2
+disableSystemMessages	KEYWORD2
+enableSplash	KEYWORD2
+disableSplash	KEYWORD2
+saveSplash	KEYWORD2
 
 
 #######################################

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun SerLCD Arduino Library
-version=1.0.6
+version=1.0.7
 author=Gaston R. Williams and Nathan Seidle
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for I2C, SPI, and Serial Communication with SparkFun SerLCD Displays


### PR DESCRIPTION
This is a fix for issue #6.  The ESP32 and ESP8266 code uses templates to define the min/max function.  This causes a compile error because the numerical literals are of implicit type (int) being compared to a byte parameter.   

Even though the types are compatible, this type mismatch causes a compile error in the template used to define the min/max function in the ESP32 and ESP8266 code.

This fix explicitly casts the numeric literals in min() and max() to type (byte) and eliminate the compile error.